### PR TITLE
响应时间超过1秒时，ftl脚本输出数字会包含逗号如：1000.00 =>html 1,000.00、

### DIFF
--- a/src/main/java/com/github/houbb/junitperf/core/jupiter/context/PerfConfigContext.java
+++ b/src/main/java/com/github/houbb/junitperf/core/jupiter/context/PerfConfigContext.java
@@ -52,7 +52,7 @@ public class PerfConfigContext implements TestTemplateInvocationContext {
     public List<Extension> getAdditionalExtensions() {
         return Collections.singletonList(
                 (TestInstancePostProcessor) (testInstance, context) -> {
-                    final Class clazz = testInstance.getClass();
+                    final Class<?> clazz = testInstance.getClass();
                     // Group test contexts by test class
                     ACTIVE_CONTEXTS.putIfAbsent(clazz, new ArrayList<>());
 

--- a/src/main/java/com/github/houbb/junitperf/model/evaluation/EvaluationContext.java
+++ b/src/main/java/com/github/houbb/junitperf/model/evaluation/EvaluationContext.java
@@ -12,6 +12,7 @@ import com.github.houbb.junitperf.support.builder.EvaluationRequireBuilder;
 import com.github.houbb.junitperf.support.builder.EvaluationResultBuilder;
 
 import org.apiguardian.api.API;
+import org.junit.jupiter.api.DisplayName;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -45,6 +46,12 @@ public class EvaluationContext implements Serializable {
     private final String methodName;
 
     /**
+     * 方法展示名称
+     * @see org.junit.jupiter.api.DisplayName
+     */
+    private final DisplayName displayName;
+
+    /**
      * 开始时间
      */
     private final String startTime;
@@ -76,6 +83,7 @@ public class EvaluationContext implements Serializable {
         this.testInstance = testInstance;
         this.testMethod = testMethod;
         this.methodName = testMethod.getName();
+        this.displayName =  testMethod.getAnnotation(DisplayName.class);
         this.startTime = startTime;
     }
 
@@ -137,6 +145,15 @@ public class EvaluationContext implements Serializable {
 
     public Method getTestMethod() {
         return testMethod;
+    }
+
+    /**
+     * 获取显示名称
+     * 有指定显示名称的话，使用显示名称
+     * @see DisplayName
+     */
+    public String getDisplayName() {
+        return displayName == null ? methodName : displayName.value();
     }
 
     @Override

--- a/src/main/resources/templates/report.ftl
+++ b/src/main/resources/templates/report.ftl
@@ -219,7 +219,7 @@
                         var data = google.visualization.arrayToDataTable([
                             ['Percentile', 'Latency', {role: "tooltip"}],
                             <#list 1..100 as i>
-                                [ ${i}, ${context.statisticsCalculator.getLatencyPercentile(i, milliseconds)} , "${i}% of executions ≤ ${context.statisticsCalculator.getLatencyPercentile(i, milliseconds)}ms"],
+                                [ ${i}, ${context.statisticsCalculator.getLatencyPercentile(i, milliseconds)?c} , "${i}% of executions ≤ ${context.statisticsCalculator.getLatencyPercentile(i, milliseconds)}ms"],
                             </#list>
                         ]);
                         var options = {

--- a/src/main/resources/templates/report.ftl
+++ b/src/main/resources/templates/report.ftl
@@ -190,11 +190,11 @@
                     <#assign active = (context_index==0) ? string("active", "")>
                     <#if context.evaluationResult.isSuccessful()>
                         <li title="${context.methodName}" class="borderRightSuccess ${active}">
-                            <a href='#${context.methodName}'>${context.methodName}</a>
+                            <a href='#${context.methodName}'>${context.displayName}</a>
                         </li>
                     <#else>
                         <li title="${context.methodName}" class="borderRightFail ${active}">
-                            <a href='#${context.methodName}'>${context.methodName}</a>
+                            <a href='#${context.methodName}'>${context.displayName}</a>
                         </li>
                     </#if>
                 </#list>
@@ -207,7 +207,7 @@
     <#list contextData as context>
 
         <div id="${context.methodName}" class="test-method">
-            <span title="${context.methodName}" class="test-method-name">${context.methodName}</span>
+            <span title="${context.methodName}" class="test-method-name">${context.displayName}</span>
 
             <div id="${context.methodName}-img" class="test-method-img">
                 <!-- ADD scatter Chart here!! -->


### PR DESCRIPTION
这样js脚本会报错，解决办法：使用freemarker内部函数?c 输出纯数字。

资料：
https://freemarker.apache.org/docs/ref_builtins_number.html#ref_builtin_c
https://blog.csdn.net/sayoko06/article/details/80272007